### PR TITLE
Fix LocalPlayer

### DIFF
--- a/src/Commands/Others/AscendDescendCommands.c
+++ b/src/Commands/Others/AscendDescendCommands.c
@@ -105,7 +105,7 @@ static void Ascend_Command(const cc_string* args, int argsCount) {
         return;
     }
 
-    struct LocalPlayer* player = (struct LocalPlayer*)Entities.List[ENTITIES_SELF_ID];
+    struct LocalPlayer* player = Entities.CurPlayer;
     struct Entity playerEntity = player->Base;
 
     Vec3 currentPosition = playerEntity.Position;
@@ -131,7 +131,7 @@ static void Descend_Command(const cc_string* args, int argsCount) {
         return;
     }
 
-    struct LocalPlayer* player = (struct LocalPlayer*)Entities.List[ENTITIES_SELF_ID];
+    struct LocalPlayer* player = Entities.CurPlayer;
     struct Entity playerEntity = player->Base;
 
     Vec3 currentPosition = playerEntity.Position;

--- a/src/Commands/Others/AscendDescendCommands.c
+++ b/src/Commands/Others/AscendDescendCommands.c
@@ -106,9 +106,9 @@ static void Ascend_Command(const cc_string* args, int argsCount) {
     }
 
     struct LocalPlayer* player = Entities.CurPlayer;
-    struct Entity playerEntity = player->Base;
+    struct Entity* playerEntity = &player->Base;
 
-    Vec3 currentPosition = playerEntity.Position;
+    Vec3 currentPosition = playerEntity->Position;
     Vec3 ascendPosition;
 
     bool success = TryFindAbove(currentPosition, &ascendPosition);
@@ -122,7 +122,7 @@ static void Ascend_Command(const cc_string* args, int argsCount) {
     update.flags = LU_HAS_POS;
     update.pos = ascendPosition;
 
-    playerEntity.VTABLE->SetLocation(&playerEntity, &update);
+    playerEntity->VTABLE->SetLocation(playerEntity, &update);
 }
 
 static void Descend_Command(const cc_string* args, int argsCount) {
@@ -132,9 +132,9 @@ static void Descend_Command(const cc_string* args, int argsCount) {
     }
 
     struct LocalPlayer* player = Entities.CurPlayer;
-    struct Entity playerEntity = player->Base;
+    struct Entity* playerEntity = &player->Base;
 
-    Vec3 currentPosition = playerEntity.Position;
+    Vec3 currentPosition = playerEntity->Position;
     Vec3 descendPosition;
 
     bool success = TryFindBelow(currentPosition, &descendPosition);
@@ -148,5 +148,5 @@ static void Descend_Command(const cc_string* args, int argsCount) {
     update.flags = LU_HAS_POS;
     update.pos = descendPosition;
 
-    playerEntity.VTABLE->SetLocation(&playerEntity, &update);
+    playerEntity->VTABLE->SetLocation(playerEntity, &update);
 }

--- a/src/Commands/Others/CmdReachDistance.c
+++ b/src/Commands/Others/CmdReachDistance.c
@@ -37,7 +37,7 @@ static void ResetReachDistance(struct LocalPlayer* player) {
 }
 
 static void ReachDistance_Command(const cc_string* args, int argsCount) {
-    struct LocalPlayer* player = (struct LocalPlayer*)Entities.List[ENTITIES_SELF_ID];
+    struct LocalPlayer* player = Entities.CurPlayer;
 
     if (argsCount == 0) {
         ResetReachDistance(player);

--- a/src/Commands/Others/CmdSpeed.c
+++ b/src/Commands/Others/CmdSpeed.c
@@ -35,7 +35,7 @@ static void ResetSpeed(struct LocalPlayer* player) {
 }
 
 static void Speed_Command(const cc_string* args, int argsCount) {
-    struct LocalPlayer* player = (struct LocalPlayer*)Entities.List[ENTITIES_SELF_ID];
+    struct LocalPlayer* player = Entities.CurPlayer;
 
     if (argsCount == 0) {
         ResetSpeed(player);

--- a/src/Player.c
+++ b/src/Player.c
@@ -2,8 +2,8 @@
 
 IVec3 Player_GetPosition(void) {
     struct LocalPlayer* player = Entities.CurPlayer;
-    struct Entity playerEntity = player->Base;
-    Vec3 currentPosition = playerEntity.Position;
+    struct Entity* playerEntity = &player->Base;
+    Vec3 currentPosition = playerEntity->Position;
 
     IVec3 position;
     position.x = (int)currentPosition.x;

--- a/src/Player.c
+++ b/src/Player.c
@@ -1,7 +1,7 @@
 #include "ClassiCube/src/Entity.h"
 
 IVec3 Player_GetPosition(void) {
-    struct LocalPlayer* player = (struct LocalPlayer*)Entities.List[ENTITIES_SELF_ID];
+    struct LocalPlayer* player = Entities.CurPlayer;
     struct Entity playerEntity = player->Base;
     Vec3 currentPosition = playerEntity.Position;
 


### PR DESCRIPTION
Replaces `(struct LocalPlayer*)Entities.List[ENTITIES_SELF_ID]` with `Entities.CurPlayer`
Fixes `LocalPlayer` for ClassiCube 1.3.7